### PR TITLE
refactor(streaming-manager): use types from types.ts for options

### DIFF
--- a/src/services/StreamingManager.ts
+++ b/src/services/StreamingManager.ts
@@ -1,4 +1,5 @@
 import { Editor, EditorPosition } from "obsidian";
+import { StreamingAnalysisOptions, LoadingIndicatorPosition } from "types";
 
 /**
  * Manages the streaming of content to the editor.
@@ -33,11 +34,7 @@ export class StreamingEditorManager {
 	 */
 	async streamAnalysis(
 		analysisPromise: Promise<string>,
-		options: {
-			streamingUpdateInterval?: number;
-			loadingIndicatorPosition?: "top" | "bottom" | "cursor";
-			chunkSize?: number;
-		} = {}
+		options: StreamingAnalysisOptions = {}
 	): Promise<void> {
 		const {
 			streamingUpdateInterval = 100,
@@ -169,7 +166,7 @@ export class StreamingEditorManager {
 	 * @param position - The position to start the loading indicator.
 	 */
 	private async startLoadingIndicator(
-		position: "top" | "bottom" | "cursor"
+		position: LoadingIndicatorPosition
 	): Promise<void> {
 		let insertLine: number;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,10 +13,20 @@ export interface AIReflectionSettings {
     outputFormat: string;
 }
 
+export type LoadingIndicatorPosition = "top" | "bottom" | "cursor";
+
 export interface StreamingOptions {
     streamingUpdateInterval?: number;
-    loadingIndicatorPosition?: 'top' | 'bottom' | 'cursor';
+    loadingIndicatorPosition?: LoadingIndicatorPosition;
     chunkSize?: number;
+}
+
+export interface StreamingAnalysisOptions {
+    streamingUpdateInterval?: number;
+    loadingIndicatorPosition?: LoadingIndicatorPosition;
+    chunkSize?: number;
+    analysisSchedule?: AnalysisSchedule;
+    communicationStyle?: CommunicationStyle;
 }
 
 // Define union types


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Refactored `StreamingEditorManager` to use the `StreamingAnalysisOptions` and `LoadingIndicatorPosition` types defined in `types.ts`, improving type safety and code maintainability.