### PR TITLE
Set up Ollama settings

### DIFF
--- a/src/settings/settingsTab.test.ts
+++ b/src/settings/settingsTab.test.ts
@@ -244,7 +244,8 @@ describe("SettingsTab", () => {
 		expect(mockPlugin.saveData).toHaveBeenCalledWith(
 			expect.objectContaining({
 				aiProvider: "ollama",
-				openaiModel: "gpt-4" // OpenAI model should be preserved
+				openaiModel: "gpt-4", // OpenAI model should be preserved
+				ollamaModel: "deepseek-r1:latest" // Ollama model should be preserved
 			})
 		);
 
@@ -257,6 +258,54 @@ describe("SettingsTab", () => {
 			expect.objectContaining({
 				aiProvider: "openai",
 				openaiModel: "gpt-4"
+			})
+		);
+	});
+	
+	test("should handle Ollama model selection", async () => {
+		// Create a new instance with ollama provider
+		const initialSettings: RecapitanSettings = {
+			aiProvider: "ollama",
+			apiKey: "",
+			analysisSchedule: "daily",
+			communicationStyle: "direct",
+			privateMarker: ":::private",
+			ollamaHost: "http://localhost:11434",
+			cacheTTLMinutes: 60,
+			cacheMaxSize: 100,
+			ollamaEndpoint: "http://localhost:11434/api/generate",
+			ollamaModel: "deepseek-r1:latest", // Start with deepseek
+			openaiModel: "gpt-4",
+			reflectionTemplate: "",
+			weeklyReflectionTemplate: ""
+		};
+
+		// Create settings tab instance with these settings
+		const testSettingsTab = new SettingsTab(
+			mockApp as App,
+			mockPlugin as Plugin,
+			initialSettings
+		);
+
+		// Change the model to llama3
+		testSettingsTab.settings.ollamaModel = "llama3.1:8b";
+		await testSettingsTab.saveSettings();
+
+		// Verify the model was saved
+		expect(mockPlugin.saveData).toHaveBeenCalledWith(
+			expect.objectContaining({
+				ollamaModel: "llama3.1:8b",
+			})
+		);
+
+		// Change to another model
+		testSettingsTab.settings.ollamaModel = "mistral:7b";
+		await testSettingsTab.saveSettings();
+
+		// Verify the new model was saved
+		expect(mockPlugin.saveData).toHaveBeenCalledWith(
+			expect.objectContaining({
+				ollamaModel: "mistral:7b",
 			})
 		);
 	});

--- a/src/settings/settingsTab.test.ts
+++ b/src/settings/settingsTab.test.ts
@@ -162,4 +162,102 @@ describe("SettingsTab", () => {
 			aiProvider: "ollama",
 		});
 	});
+
+	test("should handle OpenAI model selection", async () => {
+		// Create a new instance with openai provider
+		const initialSettings: RecapitanSettings = {
+			aiProvider: "openai",
+			apiKey: "test-key",
+			analysisSchedule: "daily",
+			communicationStyle: "direct",
+			privateMarker: ":::private",
+			ollamaHost: "http://localhost:11434",
+			cacheTTLMinutes: 60,
+			cacheMaxSize: 100,
+			ollamaEndpoint: "http://localhost:11434/api/generate",
+			ollamaModel: "deepseek-r1:latest",
+			openaiModel: "gpt-3.5-turbo", // Start with 3.5
+			reflectionTemplate: "",
+			weeklyReflectionTemplate: ""
+		};
+
+		// Create settings tab instance with these settings
+		const testSettingsTab = new SettingsTab(
+			mockApp as App,
+			mockPlugin as Plugin,
+			initialSettings
+		);
+
+		// Change the model to gpt-4
+		testSettingsTab.settings.openaiModel = "gpt-4";
+		await testSettingsTab.saveSettings();
+
+		// Verify the model was saved
+		expect(mockPlugin.saveData).toHaveBeenCalledWith(
+			expect.objectContaining({
+				openaiModel: "gpt-4",
+			})
+		);
+
+		// Change to gpt-4o
+		testSettingsTab.settings.openaiModel = "gpt-4o";
+		await testSettingsTab.saveSettings();
+
+		// Verify the new model was saved
+		expect(mockPlugin.saveData).toHaveBeenCalledWith(
+			expect.objectContaining({
+				openaiModel: "gpt-4o",
+			})
+		);
+	});
+
+	test("should maintain provider-specific settings when switching providers", async () => {
+		// Create a new instance with openai provider and settings
+		const initialSettings: RecapitanSettings = {
+			aiProvider: "openai",
+			apiKey: "test-key",
+			openaiModel: "gpt-4",
+			analysisSchedule: "daily",
+			communicationStyle: "direct",
+			privateMarker: ":::private",
+			ollamaHost: "http://localhost:11434",
+			cacheTTLMinutes: 60,
+			cacheMaxSize: 100,
+			ollamaEndpoint: "http://localhost:11434/api/generate",
+			ollamaModel: "deepseek-r1:latest",
+			reflectionTemplate: "",
+			weeklyReflectionTemplate: ""
+		};
+
+		// Create settings tab instance
+		const testSettingsTab = new SettingsTab(
+			mockApp as App,
+			mockPlugin as Plugin,
+			initialSettings
+		);
+
+		// Switch to ollama provider
+		testSettingsTab.settings.aiProvider = "ollama";
+		await testSettingsTab.saveSettings();
+
+		// Verify the provider was changed but openaiModel is preserved
+		expect(mockPlugin.saveData).toHaveBeenCalledWith(
+			expect.objectContaining({
+				aiProvider: "ollama",
+				openaiModel: "gpt-4" // OpenAI model should be preserved
+			})
+		);
+
+		// Switch back to openai
+		testSettingsTab.settings.aiProvider = "openai";
+		await testSettingsTab.saveSettings();
+
+		// Verify we switched back to openai and the model is still there
+		expect(mockPlugin.saveData).toHaveBeenCalledWith(
+			expect.objectContaining({
+				aiProvider: "openai",
+				openaiModel: "gpt-4"
+			})
+		);
+	});
 });

--- a/src/settings/settingsTab.test.ts
+++ b/src/settings/settingsTab.test.ts
@@ -12,16 +12,16 @@ import {
 import { jest } from "@jest/globals";
 
 import { MockPlugin } from '../__mocks__/MockPlugin'
-import { AIReflectionSettings } from "../types";
+import { RecapitanSettings } from "../types";
 
 
 
 // Mock SettingsTab class that avoids DOM operations
 class SettingsTab extends PluginSettingTab {
-	settings: AIReflectionSettings;
+	settings: RecapitanSettings;
 	plugin: MockPlugin;
 
-	constructor(app: App, plugin: Plugin, settings: AIReflectionSettings) {
+	constructor(app: App, plugin: Plugin, settings: RecapitanSettings) {
 		super(app, plugin);
 		this.settings = settings;
 		this.plugin = plugin as MockPlugin;
@@ -35,7 +35,7 @@ class SettingsTab extends PluginSettingTab {
 		await this.plugin.saveData(this.settings);
 	}
 
-	loadSettings(): AIReflectionSettings {
+	loadSettings(): RecapitanSettings {
 		return this.settings;
 	}
 }
@@ -99,13 +99,20 @@ describe("SettingsTab", () => {
 		jest.spyOn(mockPlugin, "loadData").mockImplementation(async () => ({}));
 
 		// Initialize settings
-		const initialSettings: AIReflectionSettings = {
+		const initialSettings: RecapitanSettings = {
 			aiProvider: "openai",
 			apiKey: "",
 			analysisSchedule: "daily",
 			communicationStyle: "direct",
-			privacyLevel: "standard",
-			outputFormat: "markdown",
+			privateMarker: ":::private",
+			ollamaHost: "http://localhost:11434",
+			cacheTTLMinutes: 60,
+			cacheMaxSize: 100,
+			ollamaEndpoint: "http://localhost:11434/api/generate",
+			ollamaModel: "deepseek-r1:latest",
+			openaiModel: "gpt-4",
+			reflectionTemplate: "",
+			weeklyReflectionTemplate: ""
 		};
 
 		// Create settings tab instance
@@ -123,12 +130,12 @@ describe("SettingsTab", () => {
 	});
 
 	test("should save settings when updated", async () => {
-		settingsTab.settings.aiProvider = "local";
+		settingsTab.settings.aiProvider = "ollama";
 		await settingsTab.saveSettings();
 
 		expect(mockPlugin.saveData).toHaveBeenCalledWith(
 			expect.objectContaining({
-				aiProvider: "local",
+				aiProvider: "ollama",
 			})
 		);
 	});
@@ -147,12 +154,12 @@ describe("SettingsTab", () => {
 
 	test("should maintain all settings when updating single value", async () => {
 		const originalSettings = { ...settingsTab.settings };
-		settingsTab.settings.aiProvider = "local";
+		settingsTab.settings.aiProvider = "ollama";
 		await settingsTab.saveSettings();
 
 		expect(mockPlugin.saveData).toHaveBeenCalledWith({
 			...originalSettings,
-			aiProvider: "local",
+			aiProvider: "ollama",
 		});
 	});
 });

--- a/src/settings/settingsTab.ts
+++ b/src/settings/settingsTab.ts
@@ -56,21 +56,22 @@ export class RecapitanSettingTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(containerEl)
-			.setName("Ollama Host")
-			.setDesc("The URL of your Ollama instance")
-			.addText((text) =>
-				text
-					.setPlaceholder("http://localhost:11434")
-					.setValue(this.plugin.settings.ollamaHost)
-					.onChange(async (value) => {
-						await this.saveSettingsWithFeedback(async () => {
-							this.plugin.settings.ollamaHost = value;
-							await this.plugin.saveSettings();
-						});
-					})
-			)
-			.setDisabled(this.plugin.settings.aiProvider !== "ollama");
+		if (this.plugin.settings.aiProvider === "ollama") {
+			new Setting(containerEl)
+				.setName("Ollama Host")
+				.setDesc("The URL of your Ollama instance")
+				.addText((text) =>
+					text
+						.setPlaceholder("http://localhost:11434")
+						.setValue(this.plugin.settings.ollamaHost)
+						.onChange(async (value) => {
+							await this.saveSettingsWithFeedback(async () => {
+								this.plugin.settings.ollamaHost = value;
+								await this.plugin.saveSettings();
+							});
+						})
+				);
+		}
 
 		new Setting(containerEl)
 			.setName("API Key")

--- a/src/settings/settingsTab.ts
+++ b/src/settings/settingsTab.ts
@@ -30,6 +30,9 @@ export class RecapitanSettingTab extends PluginSettingTab {
 		}
 	}
 
+	/**
+	 * Displays the settings UI.
+	 */
 	display(): void {
 		// Move settings UI code here...
 		const { containerEl } = this;

--- a/src/settings/settingsTab.ts
+++ b/src/settings/settingsTab.ts
@@ -73,20 +73,22 @@ export class RecapitanSettingTab extends PluginSettingTab {
 				);
 		}
 
-		new Setting(containerEl)
-			.setName("API Key")
-			.setDesc("Enter your AI provider API key")
-			.addText((text) =>
-				text
-					.setPlaceholder("Enter API key...")
-					.setValue(this.plugin.settings.apiKey)
-					.onChange(async (value) => {
-						await this.saveSettingsWithFeedback(async () => {
-							this.plugin.settings.apiKey = value;
-							await this.plugin.saveSettings();
-						});
-					})
-			);
+		if (this.plugin.settings.aiProvider === "openai") {
+			new Setting(containerEl)
+				.setName("API Key")
+				.setDesc("Enter your OpenAI API key")
+				.addText((text) =>
+					text
+						.setPlaceholder("Enter API key...")
+						.setValue(this.plugin.settings.apiKey)
+						.onChange(async (value) => {
+							await this.saveSettingsWithFeedback(async () => {
+								this.plugin.settings.apiKey = value;
+								await this.plugin.saveSettings();
+							});
+						})
+				);
+		}
 
 		new Setting(containerEl)
 			.setName("Analysis Schedule")

--- a/src/settings/settingsTab.ts
+++ b/src/settings/settingsTab.ts
@@ -31,13 +31,9 @@ export class RecapitanSettingTab extends PluginSettingTab {
 	}
 
 	/**
-	 * Displays the settings UI.
+	 * Creates the AI provider selection settings
 	 */
-	display(): void {
-		// Move settings UI code here...
-		const { containerEl } = this;
-		containerEl.empty();
-
+	private createProviderSettings(containerEl: HTMLElement): void {
 		new Setting(containerEl)
 			.setName("AI Provider")
 			.setDesc("Choose your AI provider")
@@ -56,6 +52,7 @@ export class RecapitanSettingTab extends PluginSettingTab {
 					})
 			);
 
+		// Provider-specific settings
 		if (this.plugin.settings.aiProvider === "ollama") {
 			new Setting(containerEl)
 				.setName("Ollama Host")
@@ -89,7 +86,12 @@ export class RecapitanSettingTab extends PluginSettingTab {
 						})
 				);
 		}
+	}
 
+	/**
+	 * Creates the analysis behavior settings
+	 */
+	private createAnalysisSettings(containerEl: HTMLElement): void {
 		new Setting(containerEl)
 			.setName("Analysis Schedule")
 			.setDesc("When to run the analysis")
@@ -138,7 +140,12 @@ export class RecapitanSettingTab extends PluginSettingTab {
 						});
 					})
 			);
+	}
 
+	/**
+	 * Creates the cache settings
+	 */
+	private createCacheSettings(containerEl: HTMLElement): void {
 		new Setting(containerEl)
 			.setName('Cache Duration')
 			.setDesc('How long to cache analysis results (in minutes)')
@@ -170,7 +177,12 @@ export class RecapitanSettingTab extends PluginSettingTab {
 						});
 					})
 			);
+	}
 
+	/**
+	 * Creates the template settings with text areas
+	 */
+	private createTemplateSettings(containerEl: HTMLElement): void {
 		new Setting(containerEl)
 			.setName("Daily Reflection Template")
 			.setDesc("Template for daily AI reflection prompts")
@@ -208,19 +220,47 @@ export class RecapitanSettingTab extends PluginSettingTab {
 				text.inputEl.rows = 6;
 				text.inputEl.cols = 50;
 				text.inputEl.addClass("reflection-template-input");
-
-				// Add custom styles for the textarea
-				const styleEl = document.createElement("style");
-				styleEl.innerHTML = `
-                    .reflection-template-input {
-                        width: 100%;
-                        font-family: var(--font-monospace);
-                        resize: vertical;
-                        min-height: 100px;
-                        padding: 8px;
-                    }
-                `;
-				containerEl.appendChild(styleEl);
 			});
+	}
+
+	/**
+	 * Adds custom styles for the settings
+	 */
+	private addCustomStyles(containerEl: HTMLElement): void {
+		const styleEl = document.createElement("style");
+		styleEl.innerHTML = `
+			.reflection-template-input {
+				width: 100%;
+				font-family: var(--font-monospace);
+				resize: vertical;
+				min-height: 100px;
+				padding: 8px;
+			}
+		`;
+		containerEl.appendChild(styleEl);
+	}
+
+	/**
+	 * Displays the settings UI.
+	 */
+	display(): void {
+		const { containerEl } = this;
+		containerEl.empty();
+
+		// Add section headings and call the appropriate methods
+		containerEl.createEl("h2", { text: "AI Provider Settings" });
+		this.createProviderSettings(containerEl);
+		
+		containerEl.createEl("h2", { text: "Analysis Settings" });
+		this.createAnalysisSettings(containerEl);
+		
+		containerEl.createEl("h2", { text: "Cache Settings" });
+		this.createCacheSettings(containerEl);
+		
+		containerEl.createEl("h2", { text: "Templates" });
+		this.createTemplateSettings(containerEl);
+		
+		// Add custom styles
+		this.addCustomStyles(containerEl);
 	}
 }

--- a/src/settings/settingsTab.ts
+++ b/src/settings/settingsTab.ts
@@ -85,6 +85,24 @@ export class RecapitanSettingTab extends PluginSettingTab {
 							});
 						})
 				);
+				
+			// Add OpenAI model selection
+			new Setting(containerEl)
+				.setName("OpenAI Model")
+				.setDesc("Select which OpenAI model to use")
+				.addDropdown((dropdown) =>
+					dropdown
+						.addOption("gpt-4o", "GPT-4o")
+						.addOption("gpt-4", "GPT-4")
+						.addOption("gpt-3.5-turbo", "GPT-3.5 Turbo")
+						.setValue(this.plugin.settings.openaiModel || "gpt-4")
+						.onChange(async (value) => {
+							await this.saveSettingsWithFeedback(async () => {
+								this.plugin.settings.openaiModel = value;
+								await this.plugin.saveSettings();
+							});
+						})
+				);
 		}
 	}
 

--- a/src/settings/settingsTab.ts
+++ b/src/settings/settingsTab.ts
@@ -68,6 +68,22 @@ export class RecapitanSettingTab extends PluginSettingTab {
 							});
 						})
 				);
+				
+			// Add Ollama model selection
+			new Setting(containerEl)
+				.setName("Ollama Model")
+				.setDesc("The model to use with Ollama (e.g., llama3.1:8b, deepseek-r1:latest)")
+				.addText((text) =>
+					text
+						.setPlaceholder("llama3.1:8b")
+						.setValue(this.plugin.settings.ollamaModel)
+						.onChange(async (value) => {
+							await this.saveSettingsWithFeedback(async () => {
+								this.plugin.settings.ollamaModel = value;
+								await this.plugin.saveSettings();
+							});
+						})
+				);
 		}
 
 		if (this.plugin.settings.aiProvider === "openai") {


### PR DESCRIPTION
## Summary by Sourcery

Adds a setting to configure the Ollama host URL. The Ollama host setting is only displayed when the AI provider is set to Ollama. The OpenAI API key setting is only displayed when the AI provider is set to OpenAI.

Enhancements:
- Only display the Ollama host setting when the AI provider is set to Ollama.
- Only display the OpenAI API key setting when the AI provider is set to OpenAI.