### PR TITLE
Rename the project from Project Recapitan to Retrospect AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-The AI Reflection Plugin provides thoughtful, AI-powered analysis of your daily journal entries and weekly reviews within Obsidian. It helps identify patterns, track tasks, and offer personalized insights to support your personal growth journey.
+The Retrospect AI Plugin provides thoughtful, AI-powered analysis of your daily journal entries and weekly reviews within Obsidian. It helps identify patterns, track tasks, and offer personalized insights to support your personal growth journey.
 
 ![Plugin Screenshot](assets/screenshot.png)
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
 	"id": "recapitan",
-	"name": "Recapitan",
+	"name": "Retrospect AI",
 	"version": "1.0.0",
 	"minAppVersion": "0.15.0",
-	"description": "AI-powered reflection and analysis plugin that helps you gain deeper insights from your notes and journal entries.",
+	"description": "AI-powered reflection and analysis plugin for deeper insights from your notes and journal entries.",
 	"author": "Ernie Hsiung",
 	"isDesktopOnly": false,
 	"fundingUrl": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-	"id": "recapitan",
+	"id": "retrospectai",
 	"name": "Retrospect AI",
 	"version": "1.0.0",
 	"minAppVersion": "0.15.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-	"name": "recapitan",
+	"name": "retrospect-ai",
 	"version": "1.0.0",
-	"description": "AI-powered reflection and analysis plugin for Obsidian",
+	"description": "AI-powered insights plugin for Obsidian",
 	"main": "main.js",
 	"scripts": {
 		"dev": "node esbuild.config.mjs",

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,7 +31,7 @@ export default class RetrospectAI extends Plugin {
 	async loadSettings() {
 		this.settings = Object.assign(
 			{},
-			DEFAULT_SETTINGS,
+			DEFAULT_RETROSPECT_AI_SETTINGS,
 			await this.loadData()
 		);
 	}
@@ -63,7 +63,7 @@ export default class RetrospectAI extends Plugin {
         }
 
 		this.addSettingTab(
-			new RecapitanSettingTab(this.app as ExtendedApp, this)
+			new RetrospectAISettingTab(this.app as ExtendedApp, this)
 		);
 		this.addCommands();
 	}
@@ -87,7 +87,7 @@ export default class RetrospectAI extends Plugin {
 			this.settings.loggingEnabled
 		);
 		
-		this.logger.info("Initializing Recapitan services");
+		this.logger.info("Initializing Retrospect AI services");
 		this.logger.debug(`Current AI provider: ${this.settings.aiProvider}`);
 		
 		this.privacyManager = new PrivacyManager(this.settings.privateMarker);

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,8 +7,8 @@ import {
 	Editor,
 	MarkdownFileInfo,
 } from "obsidian";
-import { RecapitanSettings, DEFAULT_SETTINGS, ExtendedApp } from "./types";
-import { RecapitanSettingTab } from "./settings/settingsTab";
+import { RetrospectAISettings, DEFAULT_RETROSPECT_AI_SETTINGS, ExtendedApp } from "./types";
+import { RetrospectAISettingTab } from "./settings/settingsTab";
 import { AnalysisManager } from "./services/AnalysisManager";
 import { AIService } from "./services/AIService";
 import { OpenAIService } from "./services/OpenAIService";
@@ -19,8 +19,8 @@ import { WeeklyAnalysisService } from "./services/WeeklyAnalysisService";
 import { LoggingService, LogLevel } from "./services/LoggingService";
 import { debounce } from "utils/debounce";
 
-export default class Recapitan extends Plugin {
-	settings!: RecapitanSettings;
+export default class RetrospectAI extends Plugin {
+	settings!: RetrospectAISettings;
 	private analysisManager!: AnalysisManager;
 	private aiService: AIService | undefined;
 	private privacyManager!: PrivacyManager;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,6 @@
 import {
 	Plugin,
 	Notice,
-	TFile,
 	MarkdownView,
 	Editor,
 	MarkdownFileInfo,

--- a/src/services/LoggingService.test.ts
+++ b/src/services/LoggingService.test.ts
@@ -1,283 +1,397 @@
-import { LoggingService, LogLevel } from './LoggingService';
-import { RecapitanSettings } from '../types';
+import { LoggingService, LogLevel } from "./LoggingService";
+import { RetrospectAISettings } from "../types";
 
-describe('LoggingService', () => {
-    // Mock console methods
-    const originalConsoleError = console.error;
-    const originalConsoleWarn = console.warn;
-    const originalConsoleInfo = console.info;
-    const originalConsoleDebug = console.debug;
-    
-    // Mock settings
-    const mockSettings: Partial<RecapitanSettings> = {
-        loggingEnabled: true,
-        logLevel: 'info'
-    };
-    
-    // Spy variables
-    let consoleErrorSpy: jest.SpyInstance;
-    let consoleWarnSpy: jest.SpyInstance;
-    let consoleInfoSpy: jest.SpyInstance;
-    let consoleDebugSpy: jest.SpyInstance;
-    
-    beforeEach(() => {
-        // Setup spies
-        consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-        consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-        consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
-        consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
-    });
-    
-    afterEach(() => {
-        // Restore original console methods
-        consoleErrorSpy.mockRestore();
-        consoleWarnSpy.mockRestore();
-        consoleInfoSpy.mockRestore();
-        consoleDebugSpy.mockRestore();
-    });
-    
-    afterAll(() => {
-        // Ensure console methods are restored
-        console.error = originalConsoleError;
-        console.warn = originalConsoleWarn;
-        console.info = originalConsoleInfo;
-        console.debug = originalConsoleDebug;
-    });
-    
-    describe('constructor', () => {
-        it('should initialize with default values', () => {
-            const logger = new LoggingService({} as RecapitanSettings);
-            expect(logger['enabled']).toBe(false);
-            expect(logger['level']).toBe(LogLevel.INFO);
-        });
-        
-        it('should initialize with provided settings', () => {
-            const logger = new LoggingService(mockSettings as RecapitanSettings, LogLevel.DEBUG, true);
-            expect(logger['enabled']).toBe(true);
-            expect(logger['level']).toBe(LogLevel.DEBUG);
-        });
-    });
-    
-    describe('setEnabled', () => {
-        it('should update the enabled state', () => {
-            const logger = new LoggingService({} as RecapitanSettings, LogLevel.INFO, false);
-            expect(logger['enabled']).toBe(false);
-            
-            logger.setEnabled(true);
-            expect(logger['enabled']).toBe(true);
-            
-            logger.setEnabled(false);
-            expect(logger['enabled']).toBe(false);
-        });
-    });
-    
-    describe('setLevel', () => {
-        it('should update the log level', () => {
-            const logger = new LoggingService({} as RecapitanSettings, LogLevel.INFO);
-            expect(logger['level']).toBe(LogLevel.INFO);
-            
-            logger.setLevel(LogLevel.DEBUG);
-            expect(logger['level']).toBe(LogLevel.DEBUG);
-            
-            logger.setLevel(LogLevel.ERROR);
-            expect(logger['level']).toBe(LogLevel.ERROR);
-        });
-    });
-    
-    describe('error', () => {
-        it('should log errors when enabled and level is sufficient', () => {
-            const logger = new LoggingService({} as RecapitanSettings, LogLevel.ERROR, true);
-            const testError = new Error('Test error');
-            
-            logger.error('Error message', testError);
-            expect(consoleErrorSpy).toHaveBeenCalledTimes(2); // Once for message, once for stack
-            expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('[ERROR] Error message'), testError);
-        });
-        
-        it('should not log errors when disabled', () => {
-            const logger = new LoggingService({} as RecapitanSettings, LogLevel.ERROR, false);
-            
-            logger.error('Error message');
-            expect(consoleErrorSpy).not.toHaveBeenCalled();
-        });
-        
-        it('should not log errors when level is insufficient', () => {
-            const logger = new LoggingService({} as RecapitanSettings, LogLevel.NONE, true);
-            
-            logger.error('Error message');
-            expect(consoleErrorSpy).not.toHaveBeenCalled();
-        });
-        
-        it('should log error stack when error object is provided', () => {
-            const logger = new LoggingService({} as RecapitanSettings, LogLevel.ERROR, true);
-            const testError = new Error('Test error');
-            
-            logger.error('Error occurred', testError);
-            expect(consoleErrorSpy).toHaveBeenCalledTimes(2);
-            // First call with message
-            expect(consoleErrorSpy.mock.calls[0][0]).toContain('[ERROR] Error occurred');
-            // Second call with stack
-            expect(consoleErrorSpy).toHaveBeenCalledWith(testError.stack);
-        });
-    });
-    
-    describe('warn', () => {
-        it('should log warnings when enabled and level is sufficient', () => {
-            const logger = new LoggingService({} as RecapitanSettings, LogLevel.WARN, true);
-            
-            logger.warn('Warning message');
-            expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringMatching(/\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\] \[WARN\] Warning message/), undefined);
-        });
-        
-        it('should not log warnings when disabled', () => {
-            const logger = new LoggingService({} as RecapitanSettings, LogLevel.WARN, false);
-            
-            logger.warn('Warning message');
-            expect(consoleWarnSpy).not.toHaveBeenCalled();
-        });
-        
-        it('should not log warnings when level is insufficient', () => {
-            const logger = new LoggingService({} as RecapitanSettings, LogLevel.ERROR, true);
-            
-            logger.warn('Warning message');
-            expect(consoleWarnSpy).not.toHaveBeenCalled();
-        });
-    });
-    
-    describe('info', () => {
-        it('should log info when enabled and level is sufficient', () => {
-            const logger = new LoggingService({} as RecapitanSettings, LogLevel.INFO, true);
-            
-            logger.info('Info message');
-            expect(consoleInfoSpy).toHaveBeenCalledWith(expect.stringMatching(/\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\] \[INFO\] Info message/), undefined);
-        });
-        
-        it('should not log info when disabled', () => {
-            const logger = new LoggingService({} as RecapitanSettings, LogLevel.INFO, false);
-            
-            logger.info('Info message');
-            expect(consoleInfoSpy).not.toHaveBeenCalled();
-        });
-        
-        it('should not log info when level is insufficient', () => {
-            const logger = new LoggingService({} as RecapitanSettings, LogLevel.WARN, true);
-            
-            logger.info('Info message');
-            expect(consoleInfoSpy).not.toHaveBeenCalled();
-        });
-    });
-    
-    describe('debug', () => {
-        it('should log debug when enabled and level is sufficient', () => {
-            const logger = new LoggingService({} as RecapitanSettings, LogLevel.DEBUG, true);
-            
-            logger.debug('Debug message');
-            expect(consoleDebugSpy).toHaveBeenCalledWith(expect.stringMatching(/\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\] \[DEBUG\] Debug message/), undefined);
-        });
-        
-        it('should not log debug when disabled', () => {
-            const logger = new LoggingService({} as RecapitanSettings, LogLevel.DEBUG, false);
-            
-            logger.debug('Debug message');
-            expect(consoleDebugSpy).not.toHaveBeenCalled();
-        });
-        
-        it('should not log debug when level is insufficient', () => {
-            const logger = new LoggingService({} as RecapitanSettings, LogLevel.INFO, true);
-            
-            logger.debug('Debug message');
-            expect(consoleDebugSpy).not.toHaveBeenCalled();
-        });
-    });
-    
-    describe('log level hierarchy', () => {
-        it('should log all levels when set to DEBUG', () => {
-            const logger = new LoggingService({} as RecapitanSettings, LogLevel.DEBUG, true);
-            
-            logger.debug('Debug message');
-            logger.info('Info message');
-            logger.warn('Warning message');
-            logger.error('Error message');
-            
-            expect(consoleDebugSpy).toHaveBeenCalled();
-            expect(consoleInfoSpy).toHaveBeenCalled();
-            expect(consoleWarnSpy).toHaveBeenCalled();
-            expect(consoleErrorSpy).toHaveBeenCalled();
-        });
-        
-        it('should log info, warn, error when set to INFO', () => {
-            const logger = new LoggingService({} as RecapitanSettings, LogLevel.INFO, true);
-            
-            logger.debug('Debug message');
-            logger.info('Info message');
-            logger.warn('Warning message');
-            logger.error('Error message');
-            
-            expect(consoleDebugSpy).not.toHaveBeenCalled();
-            expect(consoleInfoSpy).toHaveBeenCalled();
-            expect(consoleWarnSpy).toHaveBeenCalled();
-            expect(consoleErrorSpy).toHaveBeenCalled();
-        });
-        
-        it('should log warn, error when set to WARN', () => {
-            const logger = new LoggingService({} as RecapitanSettings, LogLevel.WARN, true);
-            
-            logger.debug('Debug message');
-            logger.info('Info message');
-            logger.warn('Warning message');
-            logger.error('Error message');
-            
-            expect(consoleDebugSpy).not.toHaveBeenCalled();
-            expect(consoleInfoSpy).not.toHaveBeenCalled();
-            expect(consoleWarnSpy).toHaveBeenCalled();
-            expect(consoleErrorSpy).toHaveBeenCalled();
-        });
-        
-        it('should log only error when set to ERROR', () => {
-            const logger = new LoggingService({} as RecapitanSettings, LogLevel.ERROR, true);
-            
-            logger.debug('Debug message');
-            logger.info('Info message');
-            logger.warn('Warning message');
-            logger.error('Error message');
-            
-            expect(consoleDebugSpy).not.toHaveBeenCalled();
-            expect(consoleInfoSpy).not.toHaveBeenCalled();
-            expect(consoleWarnSpy).not.toHaveBeenCalled();
-            expect(consoleErrorSpy).toHaveBeenCalled();
-        });
-        
-        it('should log nothing when set to NONE', () => {
-            const logger = new LoggingService({} as RecapitanSettings, LogLevel.NONE, true);
-            
-            logger.debug('Debug message');
-            logger.info('Info message');
-            logger.warn('Warning message');
-            logger.error('Error message');
-            
-            expect(consoleDebugSpy).not.toHaveBeenCalled();
-            expect(consoleInfoSpy).not.toHaveBeenCalled();
-            expect(consoleWarnSpy).not.toHaveBeenCalled();
-            expect(consoleErrorSpy).not.toHaveBeenCalled();
-        });
-    });
-    
-    describe('additional data logging', () => {
-        it('should log additional data with messages', () => {
-            const logger = new LoggingService({} as RecapitanSettings, LogLevel.DEBUG, true);
-            const additionalData = { userId: 123, action: 'test' };
-            
-            logger.debug('Debug message', additionalData);
-            expect(consoleDebugSpy).toHaveBeenCalledWith(
-                expect.stringContaining('[DEBUG] Debug message'), 
-                additionalData
-            );
-            
-            logger.info('Info message', additionalData);
-            expect(consoleInfoSpy).toHaveBeenCalledWith(
-                expect.stringContaining('[INFO] Info message'), 
-                additionalData
-            );
-        });
-    });
+describe("LoggingService", () => {
+	// Mock console methods
+	const originalConsoleError = console.error;
+	const originalConsoleWarn = console.warn;
+	const originalConsoleInfo = console.info;
+	const originalConsoleDebug = console.debug;
+
+	// Mock settings
+	const mockSettings: Partial<RetrospectAISettings> = {
+		loggingEnabled: true,
+		logLevel: "info",
+	};
+
+	// Spy variables
+	let consoleErrorSpy: jest.SpyInstance;
+	let consoleWarnSpy: jest.SpyInstance;
+	let consoleInfoSpy: jest.SpyInstance;
+	let consoleDebugSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		// Setup spies
+		consoleErrorSpy = jest
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+		consoleWarnSpy = jest
+			.spyOn(console, "warn")
+			.mockImplementation(() => {});
+		consoleInfoSpy = jest
+			.spyOn(console, "info")
+			.mockImplementation(() => {});
+		consoleDebugSpy = jest
+			.spyOn(console, "debug")
+			.mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		// Restore original console methods
+		consoleErrorSpy.mockRestore();
+		consoleWarnSpy.mockRestore();
+		consoleInfoSpy.mockRestore();
+		consoleDebugSpy.mockRestore();
+	});
+
+	afterAll(() => {
+		// Ensure console methods are restored
+		console.error = originalConsoleError;
+		console.warn = originalConsoleWarn;
+		console.info = originalConsoleInfo;
+		console.debug = originalConsoleDebug;
+	});
+
+	describe("constructor", () => {
+		it("should initialize with default values", () => {
+			const logger = new LoggingService({} as RetrospectAISettings);
+			expect(logger["enabled"]).toBe(false);
+			expect(logger["level"]).toBe(LogLevel.INFO);
+		});
+
+		it("should initialize with provided settings", () => {
+			const logger = new LoggingService(
+				mockSettings as RetrospectAISettings,
+				LogLevel.DEBUG,
+				true
+			);
+			expect(logger["enabled"]).toBe(true);
+			expect(logger["level"]).toBe(LogLevel.DEBUG);
+		});
+	});
+
+	describe("setEnabled", () => {
+		it("should update the enabled state", () => {
+			const logger = new LoggingService(
+				{} as RetrospectAISettings,
+				LogLevel.INFO,
+				false
+			);
+			expect(logger["enabled"]).toBe(false);
+
+			logger.setEnabled(true);
+			expect(logger["enabled"]).toBe(true);
+
+			logger.setEnabled(false);
+			expect(logger["enabled"]).toBe(false);
+		});
+	});
+
+	describe("setLevel", () => {
+		it("should update the log level", () => {
+			const logger = new LoggingService(
+				{} as RetrospectAISettings,
+				LogLevel.INFO
+			);
+			expect(logger["level"]).toBe(LogLevel.INFO);
+
+			logger.setLevel(LogLevel.DEBUG);
+			expect(logger["level"]).toBe(LogLevel.DEBUG);
+
+			logger.setLevel(LogLevel.ERROR);
+			expect(logger["level"]).toBe(LogLevel.ERROR);
+		});
+	});
+
+	describe("error", () => {
+		it("should log errors when enabled and level is sufficient", () => {
+			const logger = new LoggingService(
+				{} as RetrospectAISettings,
+				LogLevel.ERROR,
+				true
+			);
+			const testError = new Error("Test error");
+
+			logger.error("Error message", testError);
+			expect(consoleErrorSpy).toHaveBeenCalledTimes(2); // Once for message, once for stack
+			expect(consoleErrorSpy).toHaveBeenCalledWith(
+				expect.stringContaining("[ERROR] Error message"),
+				testError
+			);
+		});
+
+		it("should not log errors when disabled", () => {
+			const logger = new LoggingService(
+				{} as RetrospectAISettings,
+				LogLevel.ERROR,
+				false
+			);
+
+			logger.error("Error message");
+			expect(consoleErrorSpy).not.toHaveBeenCalled();
+		});
+
+		it("should not log errors when level is insufficient", () => {
+			const logger = new LoggingService(
+				{} as RetrospectAISettings,
+				LogLevel.NONE,
+				true
+			);
+			logger.error("Error message");
+			expect(consoleErrorSpy).not.toHaveBeenCalled();
+		});
+
+		it("should log error stack when error object is provided", () => {
+			const logger = new LoggingService(
+				{} as RetrospectAISettings,
+				LogLevel.ERROR,
+				true
+			);
+			const testError = new Error("Test error");
+
+			logger.error("Error occurred", testError);
+			expect(consoleErrorSpy).toHaveBeenCalledTimes(2);
+			// First call with message
+			expect(consoleErrorSpy.mock.calls[0][0]).toContain(
+				"[ERROR] Error occurred"
+			);
+			// Second call with stack
+			expect(consoleErrorSpy).toHaveBeenCalledWith(testError.stack);
+		});
+	});
+
+	describe("warn", () => {
+		it("should log warnings when enabled and level is sufficient", () => {
+			const logger = new LoggingService(
+				{} as RetrospectAISettings,
+				LogLevel.WARN,
+				true
+			);
+
+			logger.warn("Warning message");
+			expect(consoleWarnSpy).toHaveBeenCalledWith(
+				expect.stringMatching(
+					/\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\] \[WARN\] Warning message/
+				),
+				undefined
+			);
+		});
+
+		it("should not log warnings when disabled", () => {
+			const logger = new LoggingService(
+				{} as RetrospectAISettings,
+				LogLevel.WARN,
+				false
+			);
+
+			logger.warn("Warning message");
+			expect(consoleWarnSpy).not.toHaveBeenCalled();
+		});
+
+		it("should not log warnings when level is insufficient", () => {
+			const logger = new LoggingService(
+				{} as RetrospectAISettings,
+				LogLevel.ERROR,
+				true
+			);
+
+			logger.warn("Warning message");
+			expect(consoleWarnSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("info", () => {
+		it("should log info when enabled and level is sufficient", () => {
+			const logger = new LoggingService(
+				{} as RetrospectAISettings,
+				LogLevel.INFO,
+				true
+			);
+
+			logger.info("Info message");
+			expect(consoleInfoSpy).toHaveBeenCalledWith(
+				expect.stringMatching(
+					/\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\] \[INFO\] Info message/
+				),
+				undefined
+			);
+		});
+
+		it("should not log info when disabled", () => {
+			const logger = new LoggingService(
+				{} as RetrospectAISettings,
+				LogLevel.INFO,
+				false
+			);
+
+			logger.info("Info message");
+			expect(consoleInfoSpy).not.toHaveBeenCalled();
+		});
+
+		it("should not log info when level is insufficient", () => {
+			const logger = new LoggingService(
+				{} as RetrospectAISettings,
+				LogLevel.WARN,
+				true
+			);
+
+			logger.info("Info message");
+			expect(consoleInfoSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("debug", () => {
+		it("should log debug when enabled and level is sufficient", () => {
+			const logger = new LoggingService(
+				{} as RetrospectAISettings,
+				LogLevel.DEBUG,
+				true
+			);
+
+			logger.debug("Debug message");
+			expect(consoleDebugSpy).toHaveBeenCalledWith(
+				expect.stringMatching(
+					/\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\] \[DEBUG\] Debug message/
+				),
+				undefined
+			);
+		});
+
+		it("should not log debug when disabled", () => {
+			const logger = new LoggingService(
+				{} as RetrospectAISettings,
+				LogLevel.DEBUG,
+				false
+			);
+
+			logger.debug("Debug message");
+			expect(consoleDebugSpy).not.toHaveBeenCalled();
+		});
+
+		it("should not log debug when level is insufficient", () => {
+			const logger = new LoggingService(
+				{} as RetrospectAISettings,
+				LogLevel.INFO,
+				true
+			);
+
+			logger.debug("Debug message");
+			expect(consoleDebugSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("log level hierarchy", () => {
+		it("should log all levels when set to DEBUG", () => {
+			const logger = new LoggingService(
+				{} as RetrospectAISettings,
+				LogLevel.DEBUG,
+				true
+			);
+
+			logger.debug("Debug message");
+			logger.info("Info message");
+			logger.warn("Warning message");
+			logger.error("Error message");
+
+			expect(consoleDebugSpy).toHaveBeenCalled();
+			expect(consoleInfoSpy).toHaveBeenCalled();
+			expect(consoleWarnSpy).toHaveBeenCalled();
+			expect(consoleErrorSpy).toHaveBeenCalled();
+		});
+
+		it("should log info, warn, error when set to INFO", () => {
+			const logger = new LoggingService(
+				{} as RetrospectAISettings,
+				LogLevel.INFO,
+				true
+			);
+
+			logger.debug("Debug message");
+			logger.info("Info message");
+			logger.warn("Warning message");
+			logger.error("Error message");
+
+			expect(consoleDebugSpy).not.toHaveBeenCalled();
+			expect(consoleInfoSpy).toHaveBeenCalled();
+			expect(consoleWarnSpy).toHaveBeenCalled();
+			expect(consoleErrorSpy).toHaveBeenCalled();
+		});
+
+		it("should log warn, error when set to WARN", () => {
+			const logger = new LoggingService(
+				{} as RetrospectAISettings,
+				LogLevel.WARN,
+				true
+			);
+
+			logger.debug("Debug message");
+			logger.info("Info message");
+			logger.warn("Warning message");
+			logger.error("Error message");
+
+			expect(consoleDebugSpy).not.toHaveBeenCalled();
+			expect(consoleInfoSpy).not.toHaveBeenCalled();
+			expect(consoleWarnSpy).toHaveBeenCalled();
+			expect(consoleErrorSpy).toHaveBeenCalled();
+		});
+
+		it("should log only error when set to ERROR", () => {
+			const logger = new LoggingService(
+				{} as RetrospectAISettings,
+				LogLevel.ERROR,
+				true
+			);
+
+			logger.debug("Debug message");
+			logger.info("Info message");
+			logger.warn("Warning message");
+			logger.error("Error message");
+
+			expect(consoleDebugSpy).not.toHaveBeenCalled();
+			expect(consoleInfoSpy).not.toHaveBeenCalled();
+			expect(consoleWarnSpy).not.toHaveBeenCalled();
+			expect(consoleErrorSpy).toHaveBeenCalled();
+		});
+
+		it("should log nothing when set to NONE", () => {
+			const logger = new LoggingService(
+				{} as RetrospectAISettings,
+				LogLevel.NONE,
+				true
+			);
+
+			logger.debug("Debug message");
+			logger.info("Info message");
+			logger.warn("Warning message");
+			logger.error("Error message");
+
+			expect(consoleDebugSpy).not.toHaveBeenCalled();
+			expect(consoleInfoSpy).not.toHaveBeenCalled();
+			expect(consoleWarnSpy).not.toHaveBeenCalled();
+			expect(consoleErrorSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("additional data logging", () => {
+		it("should log additional data with messages", () => {
+			const logger = new LoggingService(
+				{} as RetrospectAISettings,
+				LogLevel.DEBUG,
+				true
+			);
+			const additionalData = { userId: 123, action: "test" };
+
+			logger.debug("Debug message", additionalData);
+			expect(consoleDebugSpy).toHaveBeenCalledWith(
+				expect.stringContaining("[DEBUG] Debug message"),
+				additionalData
+			);
+
+			logger.info("Info message", additionalData);
+			expect(consoleInfoSpy).toHaveBeenCalledWith(
+				expect.stringContaining("[INFO] Info message"),
+				additionalData
+			);
+		});
+	});
 });

--- a/src/services/LoggingService.ts
+++ b/src/services/LoggingService.ts
@@ -25,7 +25,7 @@ export class LoggingService {
      * @param enabled - Whether logging is enabled (default: false)
      */
     constructor(
-        private settings: RecapitanSettings,
+        private settings: RetrospectAISettings,
         level: LogLevel = LogLevel.INFO,
         enabled: boolean = false
     ) {

--- a/src/services/LoggingService.ts
+++ b/src/services/LoggingService.ts
@@ -1,4 +1,4 @@
-import { RecapitanSettings } from "../types";
+import { RetrospectAISettings } from "../types";
 
 /**
  * Log levels for the logging service

--- a/src/services/WeeklyAnalysisService.test.ts
+++ b/src/services/WeeklyAnalysisService.test.ts
@@ -1,7 +1,7 @@
 import { PrivacyManager } from "./PrivacyManager";
 import { WeeklyAnalysisService } from "./WeeklyAnalysisService";
 import { AIService } from "./AIService";
-import { RecapitanSettings } from "../types";
+import { RetrospectAISettings } from "../types";
 import { App } from "obsidian";
 
 describe('WeeklyAnalysisService', () => {
@@ -10,7 +10,7 @@ describe('WeeklyAnalysisService', () => {
 
     beforeEach(() => {
         const mockAIService = {} as AIService;
-        const mockSettings = {} as RecapitanSettings;
+        const mockSettings = {} as RetrospectAISettings;
         const mockApp = {} as App;
         
         privacyManager = new PrivacyManager(':::private');

--- a/src/services/WeeklyAnalysisService.ts
+++ b/src/services/WeeklyAnalysisService.ts
@@ -1,5 +1,5 @@
 // src/services/WeeklyAnalysisService.ts
-import { RecapitanSettings } from "../types";
+import { RetrospectAISettings } from "../types";
 import { App, TFile } from "obsidian";
 import { PrivacyManager } from "./PrivacyManager";
 import { AIService } from "./AIService";
@@ -11,7 +11,7 @@ export class WeeklyAnalysisService {
 	private readonly aiService: AIService;
 
 	constructor(
-		private settings: RecapitanSettings,
+		private settings: RetrospectAISettings,
 		private app: App,
 		private privacyManager: PrivacyManager,
 		aiService: AIService, // Remove private modifier here

--- a/src/settings/settingsTab.test.ts
+++ b/src/settings/settingsTab.test.ts
@@ -12,16 +12,16 @@ import {
 import { jest } from "@jest/globals";
 
 import { MockPlugin } from '../__mocks__/MockPlugin'
-import { RecapitanSettings } from "../types";
+import { RetrospectAISettings } from "../types";
 
 
 
 // Mock SettingsTab class that avoids DOM operations
 class SettingsTab extends PluginSettingTab {
-	settings: RecapitanSettings;
+	settings: RetrospectAISettings;
 	plugin: MockPlugin;
 
-	constructor(app: App, plugin: Plugin, settings: RecapitanSettings) {
+	constructor(app: App, plugin: Plugin, settings: RetrospectAISettings) {
 		super(app, plugin);
 		this.settings = settings;
 		this.plugin = plugin as MockPlugin;
@@ -35,7 +35,7 @@ class SettingsTab extends PluginSettingTab {
 		await this.plugin.saveData(this.settings);
 	}
 
-	loadSettings(): RecapitanSettings {
+	loadSettings(): RetrospectAISettings {
 		return this.settings;
 	}
 }
@@ -99,7 +99,7 @@ describe("SettingsTab", () => {
 		jest.spyOn(mockPlugin, "loadData").mockImplementation(async () => ({}));
 
 		// Initialize settings
-		const initialSettings: RecapitanSettings = {
+		const initialSettings: RetrospectAISettings = {
 			aiProvider: "openai",
 			apiKey: "",
 			analysisSchedule: "daily",
@@ -167,7 +167,7 @@ describe("SettingsTab", () => {
 
 	test("should handle OpenAI model selection", async () => {
 		// Create a new instance with openai provider
-		const initialSettings: RecapitanSettings = {
+		const initialSettings: RetrospectAISettings = {
 			aiProvider: "openai",
 			apiKey: "test-key",
 			analysisSchedule: "daily",
@@ -217,7 +217,7 @@ describe("SettingsTab", () => {
 
 	test("should maintain provider-specific settings when switching providers", async () => {
 		// Create a new instance with openai provider and settings
-		const initialSettings: RecapitanSettings = {
+		const initialSettings: RetrospectAISettings = {
 			aiProvider: "openai",
 			apiKey: "test-key",
 			openaiModel: "gpt-4",
@@ -270,7 +270,7 @@ describe("SettingsTab", () => {
 	
 	test("should handle Ollama model selection", async () => {
 		// Create a new instance with ollama provider
-		const initialSettings: RecapitanSettings = {
+		const initialSettings: RetrospectAISettings = {
 			aiProvider: "ollama",
 			apiKey: "",
 			analysisSchedule: "daily",

--- a/src/settings/settingsTab.ts
+++ b/src/settings/settingsTab.ts
@@ -1,12 +1,12 @@
 // src/settings/SettingsTab.ts
 import { PluginSettingTab, Setting, Notice } from "obsidian";
-import Recapitan from "../main";
-import { RecapitanSettings, ExtendedApp } from "../types";
+import RetrospectAI from "../main";
+import { RetrospectAISettings, ExtendedApp } from "../types";
 
-export class RecapitanSettingTab extends PluginSettingTab {
-	plugin: Recapitan;
+export class RetrospectAISettingTab extends PluginSettingTab {
+	plugin: RetrospectAI;
 
-	constructor(app: ExtendedApp, plugin: Recapitan) {
+	constructor(app: ExtendedApp, plugin: RetrospectAI) {
 		super(app, plugin);
 		this.plugin = plugin;
 	}

--- a/src/settings/settingsTab.ts
+++ b/src/settings/settingsTab.ts
@@ -45,7 +45,7 @@ export class RetrospectAISettingTab extends PluginSettingTab {
 					.onChange(async (value) => {
 						await this.saveSettingsWithFeedback(async () => {
 							this.plugin.settings.aiProvider =
-								value as RecapitanSettings["aiProvider"];
+								value as RetrospectAISettings["aiProvider"];
 							await this.plugin.saveSettings();
 							// The saveSettings method will reinitialize services
 							this.display();
@@ -142,7 +142,7 @@ export class RetrospectAISettingTab extends PluginSettingTab {
 					.onChange(async (value) => {
 						await this.saveSettingsWithFeedback(async () => {
 							this.plugin.settings.analysisSchedule =
-								value as RecapitanSettings["analysisSchedule"];
+								value as RetrospectAISettings["analysisSchedule"];
 							await this.plugin.saveSettings();
 						});
 					})
@@ -159,7 +159,7 @@ export class RetrospectAISettingTab extends PluginSettingTab {
 					.onChange(async (value) => {
 						await this.saveSettingsWithFeedback(async () => {
 							this.plugin.settings.communicationStyle =
-								value as RecapitanSettings["communicationStyle"];
+								value as RetrospectAISettings["communicationStyle"];
 							await this.plugin.saveSettings();
 						});
 					})
@@ -248,7 +248,7 @@ export class RetrospectAISettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.logLevel)
 					.onChange(async (value) => {
 						await this.saveSettingsWithFeedback(async () => {
-							this.plugin.settings.logLevel = value as RecapitanSettings["logLevel"];
+							this.plugin.settings.logLevel = value as RetrospectAISettings["logLevel"];
 							await this.plugin.saveSettings();
 						});
 					})

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,7 @@ type AnalysisSchedule = 'daily' | 'manual';
 type CommunicationStyle = 'direct' | 'gentle';
 
 // Update the RecapitanSettings interface
-export interface RecapitanSettings {
+export interface RetrospectAISettings {
     apiKey: string;
     aiProvider: AIProvider;
     openaiModel: string;  // e.g. "gpt-4o", "gpt-3.5-turbo"
@@ -56,7 +56,7 @@ export interface ExtendedApp extends App {
 	};
 }
 
-export const DEFAULT_SETTINGS: RecapitanSettings = {
+export const DEFAULT_RETROSPECT_AI_SETTINGS: RetrospectAISettings = {
     apiKey: '',
     aiProvider: 'openai',
     openaiModel: 'gpt-3.5-turbo',
@@ -70,6 +70,9 @@ export const DEFAULT_SETTINGS: RecapitanSettings = {
     cacheMaxSize: 100,
     ollamaEndpoint: 'http://localhost:11434/api/generate',
     ollamaModel: 'deepseek-r1:latest',
+    loggingEnabled: false,
+    logLevel: 'info'
+}
     loggingEnabled: false,
     logLevel: 'info'
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,7 @@ type AIProvider = 'openai' | 'ollama';
 type AnalysisSchedule = 'daily' | 'manual';
 type CommunicationStyle = 'direct' | 'gentle';
 
-// Update the RecapitanSettings interface
+// Update the RetrospectAISettings interface
 export interface RetrospectAISettings {
     apiKey: string;
     aiProvider: AIProvider;
@@ -70,9 +70,6 @@ export const DEFAULT_RETROSPECT_AI_SETTINGS: RetrospectAISettings = {
     cacheMaxSize: 100,
     ollamaEndpoint: 'http://localhost:11434/api/generate',
     ollamaModel: 'deepseek-r1:latest',
-    loggingEnabled: false,
-    logLevel: 'info'
-}
     loggingEnabled: false,
     logLevel: 'info'
 }

--- a/styles.css
+++ b/styles.css
@@ -1,15 +1,4 @@
-.recapitan-loading {
-    /* display: inline-block;
-    width: 20px;
-    height: 20px;
-    border: 2px solid var(--background-modifier-border);
-    border-radius: 50%;
-    border-top-color: var(--text-accent);
-    animation: recapitan-spin 1s linear infinite;
-    position: absolute;
-    right: 20px;
-    top: 20px; */
-
+.retrospectai-loading {
     position: absolute;
     top: 10px;
     right: 10px;
@@ -18,11 +7,11 @@
     border: 2px solid var(--background-modifier-border);
     border-top: 2px solid var(--text-accent);
     border-radius: 50%;
-    animation: recapitan-spin 1s linear infinite;
+    animation: retrospectai-spin 1s linear infinite;
     z-index: 1000;
 }
 
-@keyframes recapitan-spin {
+@keyframes retrospectai-spin {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }
 }


### PR DESCRIPTION
## Summary by Sourcery

Rename the project from Recapitan to Retrospect AI. This includes updating the plugin name, ID, description, and associated settings and references throughout the codebase.

Chores:
- Rename the project from Recapitan to Retrospect AI.
- Update plugin description.