### PR TITLE
feat: add caching and cache management commands

### DIFF
--- a/src/__tests__/CommandManager.test.ts
+++ b/src/__tests__/CommandManager.test.ts
@@ -31,6 +31,6 @@ describe("CommandManager", () => {
 
 	test("should register commands", () => {
 		commandManager.registerCommands();
-		expect(mockPlugin.addCommand).toHaveBeenCalledTimes(2);
+		expect(mockPlugin.addCommand).toHaveBeenCalledTimes(5);
 	});
 });

--- a/src/__tests__/integration/NoteAnalysisAssociation.test.ts
+++ b/src/__tests__/integration/NoteAnalysisAssociation.test.ts
@@ -66,7 +66,9 @@ const mockPlugin: Plugin & {
 		activateView: jest.fn().mockResolvedValue(undefined),
 	},
 	logger: {
-		error: jest.fn(),
+		error: jest.fn((message: string, error?: Error | unknown) => {
+			console.error(message, error);
+		}),
 		debug: jest.fn(),
 		info: jest.fn(),
 		warn: jest.fn(),
@@ -115,7 +117,10 @@ describe("Note Analysis Association Integration", () => {
 			mockPlugin as any,
 			mockAIService,
 			mockPrivacyManager,
-			mockPlugin.reflectionMemoryManager
+			mockPlugin.reflectionMemoryManager,
+			60, // cacheTTLMinutes
+			100, // cacheMaxSize
+			mockPlugin.logger // Pass the logger so error logging works
 		);
 		
 		// Create a new instance of CommentaryView
@@ -285,7 +290,10 @@ describe("Note Analysis Association Integration", () => {
 		mockPlugin as any,
 		mockAIService,
 		mockPrivacyManager,
-		mockPlugin.reflectionMemoryManager
+		mockPlugin.reflectionMemoryManager,
+		60, // cacheTTLMinutes
+		100, // cacheMaxSize
+		mockPlugin.logger // Pass the logger so error logging works
 	  );
 	  
 	  // Create a mock reflection memory manager with a properly mocked getAllReflections method

--- a/src/core/CacheCommands.ts
+++ b/src/core/CacheCommands.ts
@@ -1,0 +1,46 @@
+// src/core/CacheCommands.ts
+
+import { Notice } from "obsidian";
+import RetrospectAI from "../main";
+
+export function registerCacheCommands(plugin: RetrospectAI) {
+	plugin.addCommand({
+		id: "clear-analysis-cache",
+		name: "Clear Analysis Cache",
+		callback: () => {
+			plugin.serviceManager?.analysisManager?.clearCache();
+			new Notice("Analysis cache cleared!", 3000);
+		},
+	});
+
+	plugin.addCommand({
+		id: "toggle-analysis-cache",
+		name: "Toggle Analysis Cache",
+		callback: async () => {
+			plugin.settings.cacheEnabled = !plugin.settings.cacheEnabled;
+			await plugin.saveSettings();
+			new Notice(
+				`Analysis cache ${
+					plugin.settings.cacheEnabled ? "enabled" : "disabled"
+				}!`,
+				3000
+			);
+		},
+	});
+
+	plugin.addCommand({
+		id: "show-cache-stats",
+		name: "Show Cache Stats",
+		callback: () => {
+			const stats =
+				plugin.serviceManager?.analysisManager?.getCacheStats();
+			if (!stats) return new Notice("Cache stats unavailable", 3000);
+			new Notice(
+				`Cache: ${plugin.settings.cacheEnabled ? "on" : "off"}, Size: ${
+					stats.size
+				}, TTL: ${Math.round(stats.ttl / 60000)} min`,
+				5000
+			);
+		},
+	});
+}

--- a/src/core/CommandManager.ts
+++ b/src/core/CommandManager.ts
@@ -1,101 +1,178 @@
 // core/CommandManager.ts
-import { Editor, MarkdownView, Notice } from "obsidian";
+import { Editor, MarkdownView, Notice, MarkdownFileInfo } from "obsidian";
 import RetrospectAI from "../main";
 
 export class CommandManager {
-    private plugin: RetrospectAI;
+	private plugin: RetrospectAI;
 
-    constructor(plugin: RetrospectAI) {
-        this.plugin = plugin;
-    }
+	constructor(plugin: RetrospectAI) {
+		this.plugin = plugin;
+	}
 
-    registerCommands() {
-        this.registerAnalyzeNoteCommand();
-        this.registerWeeklyAnalysisCommand();
-    }
+	registerCommands() {
+		this.registerAnalyzeNoteCommand();
+		this.registerWeeklyAnalysisCommand();
+		this.registerCacheCommands();
+	}
 
-    private registerAnalyzeNoteCommand() {
-        this.plugin.addCommand({
-            id: "analyze-current-note",
-            name: "Analyze Current Note",
-            editorCallback: async (editor: Editor, ctx: any) => {
-                if (!(ctx instanceof MarkdownView)) {
-                    new Notice("This command can only be used in a Markdown view.", 5000);
+	private registerAnalyzeNoteCommand() {
+		this.plugin.addCommand({
+			id: "analyze-current-note",
+			name: "Analyze Current Note",
+			editorCallback: async (editor: Editor, ctx: MarkdownView | MarkdownFileInfo) => {
+                const currentFile = ("file" in ctx && ctx.file) ? ctx.file : null;
+                if (!currentFile) {
+                    new Notice("No file found in the current view", 5000);
                     return;
                 }
+				if (!(ctx instanceof MarkdownView)) {
+					new Notice(
+						"This command can only be used in a Markdown view.",
+						5000
+					);
+					return;
+				}
 
-                const content = editor.getValue();
-                const loadingNotice = new Notice("Analyzing note...", 0);
+				const content = editor.getValue();
+				const loadingNotice = new Notice("Analyzing note...", 0);
 
-                try {
-                    if (!this.plugin.serviceManager?.analysisManager) {
-                        const errorDetails = {
-                            serviceManager: !!this.plugin.serviceManager,
-                            analysisManager: !!this.plugin.serviceManager?.analysisManager,
-                            settings: this.plugin.settings
-                        };
-                        this.plugin.logger?.error("Analysis service initialization state", new Error(JSON.stringify(errorDetails)));
-                        throw new Error("Analysis service not initialized. Please check the logs for more details.");
-                    }
+				try {
+					if (!this.plugin.serviceManager?.analysisManager) {
+						const errorDetails = {
+							serviceManager: !!this.plugin.serviceManager,
+							analysisManager:
+								!!this.plugin.serviceManager?.analysisManager,
+							settings: this.plugin.settings,
+						};
+						this.plugin.logger?.error(
+							"Analysis service initialization state",
+							new Error(JSON.stringify(errorDetails))
+						);
+						throw new Error(
+							"Analysis service not initialized. Please check the logs for more details."
+						);
+					}
 
-                    // Get the current template and style from settings
-                    const template = this.plugin.settings.reflectionTemplate;
-                    const style = this.plugin.settings.communicationStyle;
+					// Get the current template and style from settings
+					const template = this.plugin.settings.reflectionTemplate;
+					const style = this.plugin.settings.communicationStyle;
 
-                    // Get the current file info
-                    const currentFile = ctx.file;
-                    if (!currentFile) {
-                        throw new Error("No file found in the current view");
-                    }
-                    const noteId = currentFile.path;
-                    const noteName = currentFile.basename;
+					// We already checked currentFile above
+					const noteId = currentFile.path;
+					const noteName = currentFile.basename;
 
-                    // Run the analysis
-                    await this.plugin.serviceManager.analysisManager.analyzeContent(
-                        content,
-                        template,
-                        style,
-                        noteId,
-                        noteName
-                    );
+					// Run the analysis
+					await this.plugin.serviceManager.analysisManager.analyzeContent(
+						content,
+						template,
+						style,
+						noteId,
+						noteName
+					);
 
-                    loadingNotice.hide();
-                    new Notice("Analysis complete! Check the side panel for results.", 3000);
-                } catch (error) {
-                    const message = error instanceof Error ? error.message : "Unknown error";
-                    loadingNotice.hide();
-                    new Notice(`Analysis failed: ${message}`, 5000);
-                    this.plugin.logger?.error("Error during note analysis", error instanceof Error ? error : new Error(String(error)));
-                }
-            },
-        });
-    }
+					loadingNotice.hide();
+					new Notice(
+						"Analysis complete! Check the side panel for results.",
+						3000
+					);
+				} catch (error) {
+					const message =
+						error instanceof Error
+							? error.message
+							: "Unknown error";
+					loadingNotice.hide();
+					new Notice(`Analysis failed: ${message}`, 5000);
+					this.plugin.logger?.error(
+						"Error during note analysis",
+						error instanceof Error
+							? error
+							: new Error(String(error))
+					);
+				}
+			},
+		});
+	}
 
-    private registerWeeklyAnalysisCommand() {
-        this.plugin.addCommand({
-            id: "analyze-past-week",
-            name: "Analyze Past Week",
-            callback: async () => {
-                const loadingNotice = new Notice("Analyzing past week...", 0);
-                if (this.plugin.uiManager.statusBarItem) {
-                    this.plugin.uiManager.statusBarItem.setText("Analyzing past week...");
-                }
-                
-                try {
-                    await this.plugin.serviceManager?.weeklyAnalysisService?.runWeeklyAnalysis();
-                    
-                    loadingNotice.hide();
-                    new Notice("Weekly analysis complete!", 3000);
-                } catch (error) {
-                    const message = error instanceof Error ? error.message : "Unknown error";
-                    loadingNotice.hide();
-                    new Notice(`Weekly analysis failed: ${message}`, 5000);
-                } finally {
-                    if (this.plugin.uiManager.statusBarItem) {
-                        this.plugin.uiManager.statusBarItem.setText("");
-                    }
-                }
-            },
-        });
-    }
+	private registerWeeklyAnalysisCommand() {
+		this.plugin.addCommand({
+			id: "analyze-past-week",
+			name: "Analyze Past Week",
+			callback: async () => {
+				const loadingNotice = new Notice("Analyzing past week...", 0);
+				if (this.plugin.uiManager.statusBarItem) {
+					this.plugin.uiManager.statusBarItem.setText(
+						"Analyzing past week..."
+					);
+				}
+
+				try {
+					await this.plugin.serviceManager?.weeklyAnalysisService?.runWeeklyAnalysis();
+
+					loadingNotice.hide();
+					new Notice("Weekly analysis complete!", 3000);
+				} catch (error) {
+					const message =
+						error instanceof Error
+							? error.message
+							: "Unknown error";
+					loadingNotice.hide();
+					new Notice(`Weekly analysis failed: ${message}`, 5000);
+				} finally {
+					if (this.plugin.uiManager.statusBarItem) {
+						this.plugin.uiManager.statusBarItem.setText("");
+					}
+				}
+			},
+		});
+	}
+	private registerCacheCommands() {
+		// Clear cache command
+		this.plugin.addCommand({
+			id: "clear-analysis-cache",
+			name: "Clear Analysis Cache",
+			callback: () => {
+				this.plugin.serviceManager?.analysisManager?.clearCache();
+				new Notice("Analysis cache cleared!", 3000);
+			},
+		});
+
+		// Toggle cache command
+		this.plugin.addCommand({
+			id: "toggle-analysis-cache",
+			name: "Toggle Analysis Cache",
+			callback: async () => {
+				const currentState = this.plugin.settings.cacheEnabled;
+				this.plugin.settings.cacheEnabled = !currentState;
+				await this.plugin.saveSettings();
+
+				const status = this.plugin.settings.cacheEnabled
+					? "enabled"
+					: "disabled";
+				new Notice(`Analysis cache ${status}!`, 3000);
+			},
+		});
+
+		// Show cache stats command
+		this.plugin.addCommand({
+			id: "show-cache-stats",
+			name: "Show Cache Stats",
+			callback: () => {
+				const stats =
+					this.plugin.serviceManager?.analysisManager?.getCacheStats();
+				if (stats) {
+					const enabled = this.plugin.settings.cacheEnabled
+						? "enabled"
+						: "disabled";
+					new Notice(
+						`Cache: ${enabled}, Size: ${
+							stats.size
+						}, TTL: ${Math.round(stats.ttl / 60000)}min`,
+						5000
+					);
+				} else {
+					new Notice("Cache stats unavailable", 3000);
+				}
+			},
+		});
+	}
 }

--- a/src/core/CommandManager.ts
+++ b/src/core/CommandManager.ts
@@ -1,166 +1,168 @@
 // core/CommandManager.ts
-import { Editor, MarkdownView, Notice, MarkdownFileInfo } from "obsidian";
+import {
+	Editor,
+	MarkdownView,
+	Notice,
+	MarkdownFileInfo,
+	TFile,
+} from "obsidian";
 import RetrospectAI from "../main";
 import { registerCacheCommands } from "./CacheCommands";
 
 export class CommandManager {
-
 	constructor(private plugin: RetrospectAI) {}
 
-	registerCommands() {
+	/**
+	 * Registers all plugin commands
+	 */
+	registerCommands(): void {
 		this.registerAnalyzeNoteCommand();
 		this.registerWeeklyAnalysisCommand();
 		registerCacheCommands(this.plugin);
 	}
 
-	private registerAnalyzeNoteCommand() {
+	/**
+	 * Registers the analyze current note command
+	 */
+	private registerAnalyzeNoteCommand(): void {
 		this.plugin.addCommand({
-		  id: 'analyze-current-note',
-		  name: 'Analyze Current Note',
-		  editorCallback: this.handleAnalyzeNote.bind(this),
+			id: "analyze-current-note",
+			name: "Analyze Current Note",
+			editorCallback: this.handleAnalyzeNote.bind(this),
 		});
 	}
 
-	private async handleAnalyzeNote(editor: Editor, ctx: MarkdownView | MarkdownFileInfo) {
-		let file = this.getFileOrNotice(ctx);
+	/**
+	 * Handles the analyze note command
+	 */
+	private async handleAnalyzeNote(
+		editor: Editor,
+		ctx: MarkdownView | MarkdownFileInfo
+	): Promise<void> {
+		const file = this.getFileOrNotice(ctx);
 		if (!file) return;
-	
-		const notice = new Notice('Analyzing note...', 0);
+
+		const notice = new Notice("Analyzing note...", 0);
 		try {
-		  this.ensureAnalysisManager();
-		  await this.plugin.serviceManager!.analysisManager!.analyzeContent(
-			editor.getValue(),
-			this.plugin.settings.reflectionTemplate,
-			this.plugin.settings.communicationStyle,
-			file.path,
-			file.basename,
-		  );
-		  notice.hide();
-		  new Notice('Analysis complete! Check the side panel for results.', 3000);
-		} catch (e) {
-		  notice.hide();
-		  this.handleError('Analysis failed', e);
+			this.ensureAnalysisManager();
+			await this.plugin.serviceManager!.analysisManager!.analyzeContent(
+				editor.getValue(),
+				this.plugin.settings.reflectionTemplate,
+				this.plugin.settings.communicationStyle,
+				file.path,
+				file.basename
+			);
+			notice.hide();
+			new Notice(
+				"Analysis complete! Check the side panel for results.",
+				3000
+			);
+		} catch (error) {
+			notice.hide();
+			this.handleError("Analysis failed", error);
 		}
-	  }
+	}
 
-	  private ensureAnalysisManager() {
+	/**
+	 * Ensures the analysis manager is initialized
+	 * @throws Error if analysis manager is not available
+	 */
+	private ensureAnalysisManager(): void {
 		if (!this.plugin.serviceManager?.analysisManager) {
-		  const details = {
-			service: !!this.plugin.serviceManager,
-			manager: !!this.plugin.serviceManager?.analysisManager,
-			settings: this.plugin.settings,
-		  };
-		  this.plugin.logger?.error('Analysis init state', new Error(JSON.stringify(details)));
-		  throw new Error('Analysis service not initialized. See logs for details.');
+			const details = {
+				service: !!this.plugin.serviceManager,
+				manager: !!this.plugin.serviceManager?.analysisManager,
+				settings: this.plugin.settings,
+			};
+			this.plugin.logger?.error(
+				"Analysis init state",
+				new Error(JSON.stringify(details))
+			);
+			throw new Error(
+				"Analysis service not initialized. See logs for details."
+			);
 		}
-	  }
-
+	}
 
 	/**
 	 * Get the file from the context or show a notice if the context is not a Markdown view or the file is not found
 	 * @param ctx The context of the command
 	 * @returns The file or null if the context is not a Markdown view or the file is not found
 	 */
-	private getFileOrNotice(ctx: MarkdownView | MarkdownFileInfo) {
+	private getFileOrNotice(
+		ctx: MarkdownView | MarkdownFileInfo
+	): TFile | null {
 		if (!(ctx instanceof MarkdownView)) {
-			new Notice('This command can only be used in a Markdown view.', 3000);
+			new Notice(
+				"This command can only be used in a Markdown view.",
+				3000
+			);
 			return null;
 		}
 		const file = ctx.file;
 		if (!file) {
-			new Notice('No file found in the current view.', 3000);
+			new Notice("No file found in the current view.", 3000);
 			return null;
 		}
 		return file;
 	}
 
-
-	private handleError(base: string, error: unknown) {
+	/**
+	 * Handles errors consistently across all commands
+	 * @param base Base error message
+	 * @param error The error that occurred
+	 */
+	private handleError(base: string, error: unknown): void {
 		const msg = error instanceof Error ? error.message : String(error);
 		new Notice(`${base}: ${msg}`, 5000);
-		this.plugin.logger?.error(base, error instanceof Error ? error : new Error(msg));
+		this.plugin.logger?.error(
+			base,
+			error instanceof Error ? error : new Error(msg)
+		);
 	}
-	
-	private registerWeeklyAnalysisCommand() {
+
+	/**
+	 * Registers the weekly analysis command
+	 */
+	private registerWeeklyAnalysisCommand(): void {
 		this.plugin.addCommand({
 			id: "analyze-past-week",
 			name: "Analyze Past Week",
-			callback: async () => {
-				const loadingNotice = new Notice("Analyzing past week...", 0);
-				if (this.plugin.uiManager.statusBarItem) {
-					this.plugin.uiManager.statusBarItem.setText(
-						"Analyzing past week..."
-					);
-				}
-
-				try {
-					await this.plugin.serviceManager?.weeklyAnalysisService?.runWeeklyAnalysis();
-
-					loadingNotice.hide();
-					new Notice("Weekly analysis complete!", 3000);
-				} catch (error) {
-					const message =
-						error instanceof Error
-							? error.message
-							: "Unknown error";
-					loadingNotice.hide();
-					new Notice(`Weekly analysis failed: ${message}`, 5000);
-				} finally {
-					if (this.plugin.uiManager.statusBarItem) {
-						this.plugin.uiManager.statusBarItem.setText("");
-					}
-				}
-			},
+			callback: this.handleWeeklyAnalysis.bind(this),
 		});
 	}
-	private registerCacheCommands() {
-		// Clear cache command
-		this.plugin.addCommand({
-			id: "clear-analysis-cache",
-			name: "Clear Analysis Cache",
-			callback: () => {
-				this.plugin.serviceManager?.analysisManager?.clearCache();
-				new Notice("Analysis cache cleared!", 3000);
-			},
-		});
 
-		// Toggle cache command
-		this.plugin.addCommand({
-			id: "toggle-analysis-cache",
-			name: "Toggle Analysis Cache",
-			callback: async () => {
-				const currentState = this.plugin.settings.cacheEnabled;
-				this.plugin.settings.cacheEnabled = !currentState;
-				await this.plugin.saveSettings();
+	/**
+	 * Handles the weekly analysis command
+	 */
+	private async handleWeeklyAnalysis(): Promise<void> {
+		const loadingNotice = new Notice("Analyzing past week...", 0);
 
-				const status = this.plugin.settings.cacheEnabled
-					? "enabled"
-					: "disabled";
-				new Notice(`Analysis cache ${status}!`, 3000);
-			},
-		});
+		this.updateStatusBar("Analyzing past week...");
 
-		// Show cache stats command
-		this.plugin.addCommand({
-			id: "show-cache-stats",
-			name: "Show Cache Stats",
-			callback: () => {
-				const stats =
-					this.plugin.serviceManager?.analysisManager?.getCacheStats();
-				if (stats) {
-					const enabled = this.plugin.settings.cacheEnabled
-						? "enabled"
-						: "disabled";
-					new Notice(
-						`Cache: ${enabled}, Size: ${
-							stats.size
-						}, TTL: ${Math.round(stats.ttl / 60000)}min`,
-						5000
-					);
-				} else {
-					new Notice("Cache stats unavailable", 3000);
-				}
-			},
-		});
+		try {
+			if (!this.plugin.serviceManager?.weeklyAnalysisService) {
+				throw new Error("Weekly analysis service not initialized");
+			}
+
+			await this.plugin.serviceManager.weeklyAnalysisService.runWeeklyAnalysis();
+			loadingNotice.hide();
+			new Notice("Weekly analysis complete!", 3000);
+		} catch (error) {
+			loadingNotice.hide();
+			this.handleError("Weekly analysis failed", error);
+		} finally {
+			this.updateStatusBar("");
+		}
+	}
+
+	/**
+	 * Updates the status bar with the given text
+	 * @param text Text to display in status bar
+	 */
+	private updateStatusBar(text: string): void {
+		if (this.plugin.uiManager.statusBarItem) {
+			this.plugin.uiManager.statusBarItem.setText(text);
+		}
 	}
 }

--- a/src/core/CommandManager.ts
+++ b/src/core/CommandManager.ts
@@ -1,97 +1,47 @@
 // core/CommandManager.ts
 import { Editor, MarkdownView, Notice, MarkdownFileInfo } from "obsidian";
 import RetrospectAI from "../main";
+import { registerCacheCommands } from "./CacheCommands";
 
 export class CommandManager {
-	private plugin: RetrospectAI;
 
-	constructor(plugin: RetrospectAI) {
-		this.plugin = plugin;
-	}
+	constructor(private plugin: RetrospectAI) {}
 
 	registerCommands() {
 		this.registerAnalyzeNoteCommand();
 		this.registerWeeklyAnalysisCommand();
-		this.registerCacheCommands();
+		registerCacheCommands(this.plugin);
 	}
 
 	private registerAnalyzeNoteCommand() {
 		this.plugin.addCommand({
-			id: "analyze-current-note",
-			name: "Analyze Current Note",
-			editorCallback: async (editor: Editor, ctx: MarkdownView | MarkdownFileInfo) => {
-                const currentFile = ("file" in ctx && ctx.file) ? ctx.file : null;
-                if (!currentFile) {
-                    new Notice("No file found in the current view", 5000);
-                    return;
-                }
-				if (!(ctx instanceof MarkdownView)) {
-					new Notice(
-						"This command can only be used in a Markdown view.",
-						5000
-					);
-					return;
-				}
-
-				const content = editor.getValue();
-				const loadingNotice = new Notice("Analyzing note...", 0);
-
-				try {
-					if (!this.plugin.serviceManager?.analysisManager) {
-						const errorDetails = {
-							serviceManager: !!this.plugin.serviceManager,
-							analysisManager:
-								!!this.plugin.serviceManager?.analysisManager,
-							settings: this.plugin.settings,
-						};
-						this.plugin.logger?.error(
-							"Analysis service initialization state",
-							new Error(JSON.stringify(errorDetails))
-						);
-						throw new Error(
-							"Analysis service not initialized. Please check the logs for more details."
-						);
-					}
-
-					// Get the current template and style from settings
-					const template = this.plugin.settings.reflectionTemplate;
-					const style = this.plugin.settings.communicationStyle;
-
-					// We already checked currentFile above
-					const noteId = currentFile.path;
-					const noteName = currentFile.basename;
-
-					// Run the analysis
-					await this.plugin.serviceManager.analysisManager.analyzeContent(
-						content,
-						template,
-						style,
-						noteId,
-						noteName
-					);
-
-					loadingNotice.hide();
-					new Notice(
-						"Analysis complete! Check the side panel for results.",
-						3000
-					);
-				} catch (error) {
-					const message =
-						error instanceof Error
-							? error.message
-							: "Unknown error";
-					loadingNotice.hide();
-					new Notice(`Analysis failed: ${message}`, 5000);
-					this.plugin.logger?.error(
-						"Error during note analysis",
-						error instanceof Error
-							? error
-							: new Error(String(error))
-					);
-				}
-			},
+		  id: 'analyze-current-note',
+		  name: 'Analyze Current Note',
+		  editorCallback: this.handleAnalyzeNote.bind(this),
 		});
 	}
+
+	private async handleAnalyzeNote(editor: Editor, ctx: MarkdownView | MarkdownFileInfo) {
+		let file = this.getFileOrNotice(ctx);
+		if (!file) return;
+	
+		const notice = new Notice('Analyzing note...', 0);
+		try {
+		  this.ensureAnalysisManager();
+		  await this.plugin.serviceManager!.analysisManager!.analyzeContent(
+			editor.getValue(),
+			this.plugin.settings.reflectionTemplate,
+			this.plugin.settings.communicationStyle,
+			file.path,
+			file.basename,
+		  );
+		  notice.hide();
+		  new Notice('Analysis complete! Check the side panel for results.', 3000);
+		} catch (e) {
+		  notice.hide();
+		  this.handleError('Analysis failed', e);
+		}
+	  }
 
 	private registerWeeklyAnalysisCommand() {
 		this.plugin.addCommand({

--- a/src/core/CommandManager.ts
+++ b/src/core/CommandManager.ts
@@ -43,6 +43,44 @@ export class CommandManager {
 		}
 	  }
 
+	  private ensureAnalysisManager() {
+		if (!this.plugin.serviceManager?.analysisManager) {
+		  const details = {
+			service: !!this.plugin.serviceManager,
+			manager: !!this.plugin.serviceManager?.analysisManager,
+			settings: this.plugin.settings,
+		  };
+		  this.plugin.logger?.error('Analysis init state', new Error(JSON.stringify(details)));
+		  throw new Error('Analysis service not initialized. See logs for details.');
+		}
+	  }
+
+
+	/**
+	 * Get the file from the context or show a notice if the context is not a Markdown view or the file is not found
+	 * @param ctx The context of the command
+	 * @returns The file or null if the context is not a Markdown view or the file is not found
+	 */
+	private getFileOrNotice(ctx: MarkdownView | MarkdownFileInfo) {
+		if (!(ctx instanceof MarkdownView)) {
+			new Notice('This command can only be used in a Markdown view.', 3000);
+			return null;
+		}
+		const file = ctx.file;
+		if (!file) {
+			new Notice('No file found in the current view.', 3000);
+			return null;
+		}
+		return file;
+	}
+
+
+	private handleError(base: string, error: unknown) {
+		const msg = error instanceof Error ? error.message : String(error);
+		new Notice(`${base}: ${msg}`, 5000);
+		this.plugin.logger?.error(base, error instanceof Error ? error : new Error(msg));
+	}
+	
 	private registerWeeklyAnalysisCommand() {
 		this.plugin.addCommand({
 			id: "analyze-past-week",

--- a/src/core/ServiceManager.ts
+++ b/src/core/ServiceManager.ts
@@ -176,7 +176,7 @@ export class ServiceManager {
 				this.privacyManager,
 				this.plugin.reflectionMemoryManager, // Pass the ReflectionMemoryManager from the plugin
 				this.plugin.settings.cacheTTLMinutes,
-				100,
+				this.plugin.settings.cacheMaxSize,
 				this.logger
 			);
 

--- a/src/core/ServiceManager.ts
+++ b/src/core/ServiceManager.ts
@@ -175,7 +175,9 @@ export class ServiceManager {
 				this.aiService as AIService,
 				this.privacyManager,
 				this.plugin.reflectionMemoryManager, // Pass the ReflectionMemoryManager from the plugin
-				this.plugin.settings.cacheTTLMinutes
+				this.plugin.settings.cacheTTLMinutes,
+				100,
+				this.logger
 			);
 
 			this.logger?.debug("Analysis Manager initialized successfully");

--- a/src/core/UIManager.ts
+++ b/src/core/UIManager.ts
@@ -40,7 +40,7 @@ export class UIManager {
 				this.statusBarItem.setText("RetrospectAI ready");
 			}
 		} catch {
-			console.log("Status bar API not available, using Notices instead");
+			// console.log("Status bar API not available, using Notices instead");
 		}
 	}
 

--- a/src/prompts/reflectionPrompt.ts
+++ b/src/prompts/reflectionPrompt.ts
@@ -1,4 +1,9 @@
-export const DEFAULT_REFLECTION_TEMPLATE = `As an insightful journaling assistant, analyze this entry with careful attention to:
+export const DEFAULT_REFLECTION_TEMPLATE = `As an insightful journaling assistant, analyze this entry with careful attention to the points below.
+
+JOURNAL ENTRY:
+{{content}}
+
+
 
 THEMES & PATTERNS
 - Identify recurring topics, ideas, or situations

--- a/src/services/AnalysisManager.ts
+++ b/src/services/AnalysisManager.ts
@@ -64,7 +64,6 @@ export class AnalysisManager {
 		logger?: LoggingService
 	) {
 		this.logger = logger;
-		console.log("Logger in AnalysisManager", logger);
 		this.logger?.debug("AnalysisManager logger is active!");
 
 		if (!aiService) {

--- a/src/services/AnalysisManager.ts
+++ b/src/services/AnalysisManager.ts
@@ -154,7 +154,6 @@ export class AnalysisManager {
 		noteName?: string
 	): Promise<AnalysisResult> {
 		try {
-			console.log("ANALYSIS MANAGER: analyzeContent...");
 			const request: AnalysisRequest = { content, template, style };
 			this.validateRequest(request);
 			this.logger?.debug(`analyzeContent request: ${JSON.stringify(request)}`);

--- a/src/services/JournalAnalysisService.ts
+++ b/src/services/JournalAnalysisService.ts
@@ -1,5 +1,5 @@
 import { App, Editor, MarkdownView, Notice, TFile } from "obsidian";
-import { AnalysisManager, AnalysisResult } from "./AnalysisManager";
+import { AnalysisManager } from "./AnalysisManager";
 import { LoggingService } from "./LoggingService";
 import { RetrospectAISettings } from "../types";
 import { ReflectionMemoryManager } from "./ReflectionMemoryManager";
@@ -47,32 +47,6 @@ export class JournalAnalysisService {
 			await this.performAnalysis(view.editor, dailyNote);
 		} catch (error) {
 			this.handleAnalysisError(error);
-		}
-	}
-
-	/**
-	 * Analyzes the content.
-	 * @param content
-	 * @param noteId
-	 * @param noteName
-	 * @returns Promise<AnalysisResult>
-	 */
-	async analyzeContent(
-		content: string,
-		noteId?: string,
-		noteName?: string
-	): Promise<AnalysisResult> {
-		try {
-			return await this.analysisManager.analyzeContent(
-				content,
-				this.settings.reflectionTemplate,
-				this.settings.communicationStyle,
-				noteId,
-				noteName
-			);
-		} catch (error) {
-			console.error("Error during content analysis:", error);
-			throw error;
 		}
 	}
 

--- a/src/settings/settingsTab.ts
+++ b/src/settings/settingsTab.ts
@@ -145,6 +145,20 @@ export class RetrospectAISettingTab extends PluginSettingTab {
 	 */
 	private createCacheSettings(containerEl: HTMLElement): void {
 		new Setting(containerEl)
+			.setName('Enable Cache')
+			.setDesc('Enable caching of analysis results (disable for development/testing)')
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.cacheEnabled)
+					.onChange(async (value) => {
+						await this.saveSettingsWithFeedback(async () => {
+							this.plugin.settings.cacheEnabled = value;
+							await this.plugin.saveSettings();
+						});
+					})
+			);
+
+		new Setting(containerEl)
 			.setName('Cache Duration')
 			.setDesc('How long to cache analysis results (in minutes)')
 			.addText((text) =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,7 @@ export interface RetrospectAISettings {
 	ollamaHost: string;
 	cacheTTLMinutes: number;
 	cacheMaxSize: number;
+	cacheEnabled: boolean;
 	loggingEnabled: boolean;
 	commentaryViewEnabled: boolean;
 	logLevel: LogLevel;
@@ -80,6 +81,7 @@ export const DEFAULT_RETROSPECT_AI_SETTINGS: RetrospectAISettings = {
 	ollamaHost: "http://localhost:11434",
 	cacheTTLMinutes: 60,
 	cacheMaxSize: 100,
+	cacheEnabled: true,
 	ollamaEndpoint: "http://localhost:11434/api/generate",
 	ollamaModel: "deepseek-r1:latest",
 	loggingEnabled: false,


### PR DESCRIPTION
This commit introduces several enhancements to the caching system within the CommandManager and AnalysisManager. A new import, MarkdownFileInfo, is added to CommandManager.ts to improve file handling. The CommandManager now includes commands to clear the analysis cache, toggle the cache on and off, and display cache statistics. The AnalysisManager is updated to support these new features, including conditional caching based on the new cacheEnabled setting. Additionally, the settingsTab.ts is updated to allow users to enable or disable the cache via the plugin settings UI. The commit also includes various debug logging improvements to assist with development and troubleshooting.

## Summary by Sourcery

Add a configurable caching layer to the analysis workflow, surface cache management commands in CommandManager, wire up the cacheEnabled toggle in settingsTab, and augment AnalysisManager with conditional caching and debug logging support.

New Features:
- Add commands to clear, toggle, and display analysis cache stats
- Introduce a cacheEnabled setting with a toggle in the plugin settings UI

Enhancements:
- Implement conditional caching in AnalysisManager based on cacheEnabled setting
- Integrate LoggingService into AnalysisManager for debug logging
- Refactor CommandManager to support MarkdownFileInfo contexts
- Enhance the default reflection prompt template with an explicit JOURNAL ENTRY section

Chores:
- Add cacheEnabled field to settings and default values
- Update ServiceManager to pass cache configuration and logger to AnalysisManager